### PR TITLE
Dynamic Module support

### DIFF
--- a/config
+++ b/config
@@ -1,4 +1,16 @@
 ngx_addon_name=ngx_http_auth_pam_module
-HTTP_MODULES="$HTTP_MODULES ngx_http_auth_pam_module"
-NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_auth_pam_module.c"
-CORE_LIBS="$CORE_LIBS -lpam"
+
+if test -n "$ngx_module_link"; then
+    ngx_module_type=HTTP
+    ngx_module_name=ngx_http_auth_pam_module
+    ngx_module_incs=
+    ngx_module_deps=
+    ngx_module_srcs="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_auth_pam_module.c"
+    ngx_module_libs="$CORE_LIBS -lpam"
+
+    . auto/module
+else
+   HTTP_MODULES="$HTTP_MODULES ngx_http_auth_pam_module"
+   NGX_ADDON_SRCS="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_auth_pam_module.c"
+   CORE_LIBS="$CORE_LIBS -lpam"
+fi


### PR DESCRIPTION
Changed the config file so it can compile as a Dynamic Module or as a Normal module.

example:
For dynamic module use: --add-dynamic-module=/etc/nginx/modules/pamauth
For normal module use: --add-module=/etc/nginx/modules/pamauth

Both worked fine for me with the changes to the config file.