### PR TITLE
Fix building alongside other modules in nginx 1.9.11+

### DIFF
--- a/config
+++ b/config
@@ -5,8 +5,8 @@ if test -n "$ngx_module_link"; then
     ngx_module_name=ngx_http_auth_pam_module
     ngx_module_incs=
     ngx_module_deps=
-    ngx_module_srcs="$NGX_ADDON_SRCS $ngx_addon_dir/ngx_http_auth_pam_module.c"
-    ngx_module_libs="$CORE_LIBS -lpam"
+    ngx_module_srcs="$ngx_addon_dir/ngx_http_auth_pam_module.c"
+    ngx_module_libs="-lpam"
 
     . auto/module
 else


### PR DESCRIPTION
This PR fixes a bug in the config script which prevents nginx 1.9.11+ from building if ngx_http_auth_pam_module is included alongside other third-party modules. (If ngx_http_auth_pam_module is the only third-party module it works, which I guess is why it wasn't found during testing.)

Full details from the commit message:

The auto/module script appends $ngx_module_libs to $CORE_LIBS itself.
Including $CORE_LIBS in $ngx_module_libs causes libraries used by any
third-party modules added prior to ngx_http_auth_pam_module to be
duplicated in the $CORE_LIBS array.

Similarly, the auto/module script appends $ngx_module_srcs to
$NGX_ADDON_SRCS (or another array, depending on the value of
$ngx_module_link) itself. Including $NGX_ADDON_SRCS in $ngx_module_srcs
ultimately cause nginx's configure script to produce a Makefile that passes the
same .o files from other third-party modules multiple times to the
linker, which causes the build to fail with duplicate symbol errors.

This commit fixes both issues by removing $CORE_LIBS and $NGX_ADDON_SRCS
from $ngx_module_libs and $ngx_module_srcs respectively.